### PR TITLE
Fixing PSR-4 Autoloading Issue in Probots\Pinecone\Requests\Exceptions\MissingNameException

### DIFF
--- a/src/Exceptions/MissingNameException.php
+++ b/src/Exceptions/MissingNameException.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Probots\Pinecone\Requests\Exceptions;
+namespace Probots\Pinecone\Exceptions;
 
 use Saloon\Exceptions\SaloonException;
 
 class MissingNameException extends SaloonException
 {
-
 }


### PR DESCRIPTION
This pull request resolves the PSR-4 autoloading issue for the MissingNameException class in the `Probots\Pinecone\Requests\Exceptions` namespace. 

```
Class Probots\Pinecone\Requests\Exceptions\MissingNameException located in 
(...)/vendor/probots-io/pinecone-php/src\Exceptions\MissingNameException.php
does not comply with psr-4 autoloading standard. Skipping.
```

I have updated the namespace to `Probots\Pinecone\Exceptions` to align with the folder structure. 

