### PR TITLE
Upgrade | Use saloonphp/saloon instead of Sammyjo20/Saloon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "sammyjo20/saloon": "^2.7"
+    "saloonphp/saloon": "^2.7"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR just changes the package name from `sammyjo20/saloon` to `saloonphp/saloon`.

Have a great day!