### PR TITLE
Add note in readme about index host format

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ $pinecone = new Pinecone($apiKey, $indexHost);
 
 // all control AND data methods are available now
 ```
+> **Info**
+> The index host should include `https://`, which you may need to prepend to the value returned from Pinecone.
 
 ## Responses
 


### PR DESCRIPTION
The pinecone Describe Indexes endpoint returns the host without "https://" at the start. If that value is used directly to initialize the probots client, all data plane requests result in a curl timeout. It would be helpful to point this out in the readme.