### PR TITLE
Php multiple version support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version: [8.1, 8.2, 8.3]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -13,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: ${{ matrix.php-version }}
           tools: composer:v2
           coverage: xdebug
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^8.2",
+    "php": "^8.1",
     "saloonphp/saloon": "^3.6"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "scotteuser/pinecone-php",
+  "name": "probots-io/pinecone-php",
   "description": "Unofficial PHP Client for Pinecone Vector Database (pinecone.io)",
   "type": "library",
   "homepage": "https://probots.io",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "probots-io/pinecone-php",
+  "name": "scotteuser/pinecone-php",
   "description": "Unofficial PHP Client for Pinecone Vector Database (pinecone.io)",
   "type": "library",
   "homepage": "https://probots.io",


### PR DESCRIPTION
(Copied from https://github.com/probots-io/pinecone-php/pull/13 to change source branch - sorry!)

Thank you for this excellent project. We have started using it in https://www.drupal.org/project/ai and will contribute back where we can. We would like to keep the module as compatible as possible with the range of PHP versions Drupal supports (https://www.drupal.org/docs/getting-started/system-requirements/php-requirements) which matches the wider PHP versions supported (https://www.php.net/supported-versions.php).

Tests currently support only PHP 8.2. This PR changes the github workflow to test 8.1, 8.2, and 8.3 + changes the composer.json to have a minimum version of PHP 8.1 (which is also what saloonphp/saloon requires).

To note, I did run the tests locally in 8.1, 8.2, and 8.3 all passing fine.

Thank you!