### PR TITLE
Add attribution user agent to get listed on Pinecone Integrations

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -70,7 +70,7 @@ class Client extends Connector implements ClientContract
             'Api-Key'      => $this->apiKey,
             'Accept'       => 'application/json;',
             'Content-Type' => 'application/json',
-            'User-Agent'   => 'probots-io--pinecone-php'
+            'User-Agent'   => 'probots_io:pinecone_php'
         ];
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -69,7 +69,8 @@ class Client extends Connector implements ClientContract
         return [
             'Api-Key'      => $this->apiKey,
             'Accept'       => 'application/json;',
-            'Content-Type' => 'application/json'
+            'Content-Type' => 'application/json',
+            'User-Agent'   => 'probots-io--pinecone-php'
         ];
     }
 


### PR DESCRIPTION
In order to get listed on https://docs.pinecone.io/integrations/overview there should be an attribution following their guidelines here: https://docs.pinecone.io/integrations/build-integration/attribute-usage-to-your-integration

PR adds this to default headers