### PR TITLE
Allow php 8.2+ rather than 8.3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^8.3",
+    "php": "^8.2",
     "saloonphp/saloon": "^3.6"
   },
   "autoload": {


### PR DESCRIPTION
composer.json specified minimum 8.1 in https://github.com/probots-io/pinecone-php/pull/17/files which got merged but it looks like you switched it back to 8.3 later. Can we at least do 8.2 since its supported for another year https://www.php.net/supported-versions.php (8.1 is now about to hit EOL)

It prevents us from directly using your repo in the Drupal Pinecone module since we have to support stable versions to match Drupal Core's policy there.

Or was there something specific stopping 8.1/8.2 from being supported?

Thanks!